### PR TITLE
Improve getContent provider and simplify home controller

### DIFF
--- a/app/components/get-content/get-content.service.js
+++ b/app/components/get-content/get-content.service.js
@@ -1,6 +1,18 @@
 (function(angular) {
     'use strict';
 
+    /**
+     * @filedesc Creates a service that is capable of accessing the document content (currently just as OOXML).
+     *
+     * A public `getContent` service is registered which delegates to a `getContentBackend` provider. This is done so that
+     * we can have environment specific implementations without changing the service, or having to inject different services
+     * to consumers.
+     *
+     * The result is that when running in Office, we can use the 'real' implementation by providing a `getContentBackend`
+     * that uses the Office API(s), but when running in a browser based environment (e.g. for development or unit testing)
+     * we can swap out the backend for one with the same contract but returns some mock data.
+     */
+
     angular.module('word-to-markdown.get-content', [
         'word-to-markdown.platform'
     ])

--- a/app/components/get-content/get-content.service.js
+++ b/app/components/get-content/get-content.service.js
@@ -4,12 +4,35 @@
     angular.module('word-to-markdown.get-content', [
         'word-to-markdown.platform'
     ])
-        .provider('getContent', getContentProvider);
+        .service('getContent', GetContentService)
+        .provider('getContentBackend', getContentBackendProvider);
+
+    /**
+     * @class {GetContentService}
+     * @param {GetContentBackendOfficeService|GetContentBackendBrowserService} getContentBackend
+     * @constructor
+     */
+    function GetContentService(getContentBackend) {
+        /**
+         * @type {GetContentBackendOfficeService|GetContentBackendBrowserService}
+         * @private
+         */
+        this._getContentBackend = getContentBackend;
+    }
+
+    /**
+     * Call through to the getContentBackend implementation, which will differ per platform
+     *
+     * @returns {Promise.<string>} OOXML representation of the entire Word document
+     */
+    GetContentService.prototype.getDocumentAsOoxml = function() {
+        return this._getContentBackend.getDocumentAsOoxml.apply(this._getContentBackend, arguments);
+    };
 
     /**
      * Load different backends so we can run this in Office environment and stub the response when running in a browser
      */
-    function getContentProvider() {
+    function getContentBackendProvider() {
         /**
          * @param {PlatformService} platform
          * @param {angular.$q} $q

--- a/app/components/markdown-converter/markdown-converter.service.js
+++ b/app/components/markdown-converter/markdown-converter.service.js
@@ -7,9 +7,30 @@
     /**
      * @class MarkdownConverterService
      * @constructor
+     *
+     * @param {GetContentService} getContent
      */
-    function MarkdownConverterService() {
+    function MarkdownConverterService(getContent) {
+        /**
+         * @type {GetContentService}
+         * @private
+         */
+        this._getContent = getContent;
     }
+
+    /**
+     * Converts the full Word document to Markdown syntax
+     *
+     * @returns {Promise.<string>}
+     */
+    MarkdownConverterService.prototype.convertDocumentToMarkdown = function() {
+        var _this = this;
+
+        return this._getContent.getDocumentAsOoxml()
+            .then(function(ooxml) {
+                return _this.convertFromOoxml(ooxml);
+            });
+    };
 
     /**
      * @param {string} html

--- a/app/home/home.controller.js
+++ b/app/home/home.controller.js
@@ -5,18 +5,11 @@
       .controller('HomeController', HomeController);
 
   /**
-   * Controller constructor
+   * Home Controller constructor
    *
-   * @param {GetContentService} getContent
    * @param {MarkdownConverterService} markdownConverter
    */
-  function HomeController(getContent, markdownConverter) {
-    /**
-     * @type {GetContentService}
-     * @private
-     */
-    this._getContent = getContent;
-
+  function HomeController(markdownConverter) {
     /**
      * @type {MarkdownConverterService}
      * @private
@@ -44,13 +37,16 @@
     this._isLoading = true; // set as loading
     this.markdown = ''; // reset converted markdown
 
-    this._getContent.getDocumentAsOoxml()
-        .then(function(ooxml) {
-          _this.markdown = _this._markdownConverter.convertFromOoxml(ooxml);
-        })
-        .finally(function() {
-          _this._isLoading = false;
-        });
+    this._markdownConverter.convertDocumentToMarkdown()
+      .then(function(markdown) {
+        _this.markdown = markdown;
+      })
+      .catch(function(error) {
+        // todo: handle error
+      })
+      .finally(function() {
+        _this._isLoading = false;
+      });
   };
 
   /**


### PR DESCRIPTION
- [x] Add `getContent` service that just injects `getContentBackend` (service is now agnostic of platform specific implementation)
- [x] Add `getContentBackend` provider that loads either the Office or Browser implementations of the backend
- [x] Add `getDocumentAsMarkdown` to `markdownConverter` service- allows for less dependencies to be injected into controllers and the steps to get the output minimised
- [x] Simplify `HomeController` in line with above
- [x] Add docs for why `getContentBackend` exists
