### PR TITLE
[style][refactor] Various view and controller fixes

### DIFF
--- a/app/components/translations/translations.js
+++ b/app/components/translations/translations.js
@@ -12,14 +12,14 @@
    */
   function registerTranslations($translateProvider) {
     $translateProvider.translations('en', {
-      'w2md.convert-document': 'Convert',
-      'w2md.convert-document-to-markdown': 'Convert document to markdown',
-      'w2md.converted-document-to-markdown': 'Converted document to markdown',
-      'w2md.click-to-convert': 'Click the button below to convert your Word document to Markdown.',
+      'w2md.convert-selection': 'Convert selection',
+      'w2md.convert-selection-to-markdown': 'Convert selection to markdown',
+      'w2md.converted-selection-to-markdown': 'Converted selection to markdown',
+      'w2md.click-to-convert': 'Click the button below to convert the selected text to Markdown.',
       'w2md.intro-to-markdown': 'Markdown is a widely used syntax that is used for a variety of different purposes, ' +
       'from blogging platforms to project documentation.',
       'w2md.wont-change-document': 'Note that this will not change your original document.',
-      'w2md.conversion-complete-message': 'The markdown version of your Word document is shown below. Note that this ' +
+      'w2md.conversion-complete-message': 'The markdown version of your selection is shown below. Note that this ' +
       'does not live update as you make further changes to your document. You\'ll need to do this again if you ' +
       'make any additional changes.',
       'w2md.back-to-start': 'Go back to the start'

--- a/app/states/home/home.controller.js
+++ b/app/states/home/home.controller.js
@@ -30,7 +30,7 @@
    *
    * @returns {undefined}
    */
-  HomeController.prototype.convertDocument = function() {
+  HomeController.prototype.convertSelection = function() {
     var _this = this;
 
     this._isLoading = true;

--- a/app/states/home/home.controller.test.js
+++ b/app/states/home/home.controller.test.js
@@ -29,13 +29,13 @@ describe('home controller', function() {
     }));
 
     it('should try to take the user to the output state', function() {
-      homeController.convertDocument();
+      homeController.convertSelection();
 
       expect($state.go).toHaveBeenCalledWith('output');
     });
 
     it('should hide the convert button after it is pressed', function() {
-      homeController.convertDocument();
+      homeController.convertSelection();
       expect(homeController.shouldShowConvertButton()).toBe(false);
     });
   });

--- a/app/states/home/home.html
+++ b/app/states/home/home.html
@@ -1,9 +1,13 @@
 <div class="home-view">
-    <h1>{{ ::'w2md.convert-document-to-markdown' | translate }}</h1>
+    <h2>{{ ::'w2md.convert-selection-to-markdown' | translate }}</h2>
 
     <p>{{ ::'w2md.intro-to-markdown' | translate }}</p>
     <p>{{ ::'w2md.click-to-convert' | translate }}</p>
     <p><strong>{{ ::'w2md.wont-change-document' | translate }}</strong></p>
 
-    <button ng-show="vm.shouldShowConvertButton()" ng-click="vm.convertDocument()">{{ ::'w2md.convert-document' | translate }}</button>
+    <button class="ms-Button ms-Button--primary"
+            ng-show="vm.shouldShowConvertButton()"
+            ng-click="vm.convertSelection()">
+        <span class="ms-Button-label">{{ ::'w2md.convert-selection' | translate }}</span>
+    </button>
 </div>

--- a/app/states/output/output.html
+++ b/app/states/output/output.html
@@ -1,9 +1,12 @@
 <div class="output-view">
-    <h1>{{ ::'w2md.converted-document-to-markdown' | translate }}</h1>
+    <h1>{{ ::'w2md.converted-selection-to-markdown' | translate }}</h1>
 
     <p>{{ ::'w2md.conversion-complete-message' | translate }}</p>
 
-    <button ui-sref="home">{{ ::'w2md.back-to-start' | translate }}</button>
+    <button class="ms-Button ms-Button--primary"
+            ui-sref="home">
+         <span class="ms-Button-label">{{ ::'w2md.back-to-start' | translate }}</span>
+    </button>
 
     <textarea class="markdown-content" readonly="readonly">{{ vm.markdown }}</textarea>
 </div>

--- a/app/states/output/output.html
+++ b/app/states/output/output.html
@@ -1,5 +1,5 @@
 <div class="output-view">
-    <h1>{{ ::'w2md.converted-selection-to-markdown' | translate }}</h1>
+    <h2>{{ ::'w2md.converted-selection-to-markdown' | translate }}</h2>
 
     <p>{{ ::'w2md.conversion-complete-message' | translate }}</p>
 

--- a/content/app.css
+++ b/content/app.css
@@ -19,7 +19,6 @@
     transform: scale3d(0, 0, 0);
 }
 
-
 .main-view {
-    padding: 0.5em;
+    padding: 0 1.5em;
 }

--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
   <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
 
   <!-- Vendor CSS -->
+  <link href="content/Office.css" rel="stylesheet" />
+  <link href="bower_components/microsoft.office.js/styles/OfficeThemes.css" rel="stylesheet" />
   <link href="bower_components/office-ui-fabric/dist/css/fabric.min.css" rel="stylesheet" />
   <link href="bower_components/office-ui-fabric/dist/css/fabric.components.min.css" rel="stylesheet" />
-  <link href="content/Office.css" rel="stylesheet" />
   <link href="content/app.css" rel="stylesheet" />
-  <link href="bower_components/microsoft.office.js/styles/OfficeThemes.css" rel="stylesheet" />
 
   <!-- State CSS -->
   <link href="app/states/home/home.css" rel="stylesheet" />


### PR DESCRIPTION
- [x] Change translations to state that conversion is for selection, not for document
- [x] Change ordering of Office CSS so that overrides behave correctly
- [x] Set correct padding on main container
- [x] Set method name on controller to specify that conversion is for selection, not document
- [x] Add Office Fabric CSS classes to buttons
